### PR TITLE
optimize kappa, type stability, logcdf in EE.jl

### DIFF
--- a/src/ExtendedExtremes.jl
+++ b/src/ExtendedExtremes.jl
@@ -12,6 +12,7 @@ import Distributions.minimum
 import Distributions.maximum
 import Distributions.insupport
 import Distributions.cdf
+import Distributions.logcdf  # pour fit_mle
 import Distributions.loglikelihood
 import Distributions.logpdf
 import Distributions.pdf
@@ -49,7 +50,7 @@ export
     maximum,
     insupport,   # predicate, is x in the support of the distribution?
     getdistribution,
-    #logcdf,      # cdf returning log-probability
+    logcdf,      # cdf returning log-probability
     cdf,         # cumulative distribution function
     logpdf,      # log probability density
     pdf,         # probability density function

--- a/src/distributions/Power.jl
+++ b/src/distributions/Power.jl
@@ -32,19 +32,18 @@ function cdf(pd::Power, x::Real)
 end
 
 function logcdf(pd::Power, x::Real)
-    κ = first(params(pd))
-    temp = x < zero(x) ? oftype(x, -Inf) : κ*log(x)
+    temp = x < zero(x) ? oftype(x, -Inf) : pd.κ*log(x)
     return x > one(x) ? zero(x) : temp
 end
 
 function logpdf(pd::Power, x::Real)
-    κ = first(params(pd))
+    κ = pd.κ
     p = log(κ) + (κ - 1.)*log(x)
     return (zero(x) < x < one(x)) ? p : oftype(p, -Inf)
 end
 
 function loglikelihood(pd::Power, x::Vector{<:Real})
-    κ = first(params(pd))
+    κ = pd.κ
     n = length(x)
     s = sum(log, x)
     return n*log(κ) + (κ - 1.)*s 
@@ -52,12 +51,10 @@ end
 
 function quantile(pd::Power, p::Real)
     @assert zero(p) < p < one(p)
-    κ = first(params(pd))
-    return p^(1. / κ)    
+    return p^(1. / pd.κ)    
 end
 
 function rand(rng::AbstractRNG, pd::Power)
-    κ = first(params(pd))
-    dist = Beta(κ, 1.)
+    dist = Beta(pd.κ, 1.)
     return rand(rng, dist)
 end


### PR DESCRIPTION
Optimize kappa : pd.kappa instead of params(pd)[1]
type stability : ones(x) instead of 1 ...
import Distributions.logcdf and export logcdf in ExtendedExtremes.jl